### PR TITLE
Fix SinceVersion field for FontFile2 entry in FontDescriptorTrueType

### DIFF
--- a/tsv/latest/FontDescriptorTrueType.tsv
+++ b/tsv/latest/FontDescriptorTrueType.tsv
@@ -18,4 +18,4 @@ AvgWidth	number	1.0		FALSE	FALSE	FALSE	0
 MaxWidth	number	1.0		FALSE	FALSE	FALSE	0				
 MissingWidth	number	1.0		FALSE	FALSE	FALSE	0				
 FontFile	stream	1.1		FALSE	TRUE	FALSE			[fn:Eval(fn:Not(fn:IsPresent(FontFile2)))]	[FontFileType1]	Table 124
-FontFile2	stream	1.2		FALSE	TRUE	FALSE			[fn:Eval(fn:Not(fn:IsPresent(FontFile)))]	[FontFile2]	Table 124
+FontFile2	stream	1.1		FALSE	TRUE	FALSE			[fn:Eval(fn:Not(fn:IsPresent(FontFile)))]	[FontFile2]	Table 124


### PR DESCRIPTION
ISO 32000-2, Table 120, key FontFile2 - `(Optional; PDF 1.1)`. 
And this key actually introduced in PDF 1.1.