### PR TITLE
Fix SpecialCase field for ArrayOfIndirectFileSpecifications object

### DIFF
--- a/tsv/latest/ArrayOfIndirectFileSpecifications.tsv
+++ b/tsv/latest/ArrayOfIndirectFileSpecifications.tsv
@@ -1,2 +1,2 @@
 Key	Type	SinceVersion	DeprecatedIn	Required	IndirectReference	Inheritable	DefaultValue	PossibleValues	SpecialCase	Link	Note
-*	dictionary	fn:Eval(fn:Extension(ADBE_Extn3,1.7) || 2.0)		FALSE	TRUE	FALSE			[fn:InNameTree(parent::parent::RichMediaContent::Assets)]	[FileSpecification]	https://github.com/pdf-association/pdf-issues/issues/59
+*	dictionary	fn:Eval(fn:Extension(ADBE_Extn3,1.7) || 2.0)		FALSE	TRUE	FALSE			[fn:InNameTree(parent::parent::parent::RichMediaContent::Assets)]	[FileSpecification]	https://github.com/pdf-association/pdf-issues/issues/59


### PR DESCRIPTION
The previous fix was not sufficient https://github.com/pdf-association/arlington-pdf-model/pull/150

The `RichMediaContent` entry located in the `AnnotRichMedia` object.

`AnnotRichMedia` -> `RichMediaSettings` -> `RichMediaActivation` -> `ArrayOfIndirectFileSpecifications`.

So should be 3 `parent::` in path.

